### PR TITLE
Fixed import error in StatisticsPointList.py

### DIFF
--- a/ClearMap/ParallelProcessing/DataProcessing/statistics/StatisticsPointList.py
+++ b/ClearMap/ParallelProcessing/DataProcessing/statistics/StatisticsPointList.py
@@ -26,7 +26,7 @@ import ClearMap.IO.IO as io
 
 import ClearMap.ParallelProcessing.DataProcessing.ArrayProcessing as ap
 
-import ClearMap.ParallelProcessing.DataProcessing.StatisticsPointListCode as code
+import ClearMap.ParallelProcessing.DataProcessing.statistics.StatisticsPointListCode as code
 
 ###############################################################################
 ### Voxelization


### PR DESCRIPTION
The change in [this commit](https://github.com/ChristophKirst/ClearMap2/commit/5cf4849d8d5cdcb698a3d718840e59a535f2eeda) was causing `import ClearMap.Compile` as outlined in the installation docs to fail with the error
```
>>> import ClearMap.Compile
ClearMap.ImageProcessing.Binary.Filling
ClearMap.ImageProcessing.Clipping.Clipping
ClearMap.ImageProcessing.Differentiation.Hessian
ClearMap.ImageProcessing.Filter.Rank
ClearMap.ImageProcessing.Thresholding.Thresholding
ClearMap.ImageProcessing.Tracing.Trace
ClearMap.ParallelProcessing.DataProcessing.ArrayProcessing
ClearMap.ParallelProcessing.DataProcessing.ConvolvePointList
ClearMap.ParallelProcessing.DataProcessing.DevolvePointList
ClearMap.ParallelProcessing.DataProcessing.MeasurePointList
ClearMap.ParallelProcessing.DataProcessing.StatisticsPointList
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/ClearMap2/ClearMap/Compile.py", line 48, in <module>
    import ClearMap.ParallelProcessing.DataProcessing.statistics.StatisticsPointList as spl
  File "/ClearMap2/ClearMap/ParallelProcessing/DataProcessing/statistics/StatisticsPointList.py", line 29, in <module>
    import ClearMap.ParallelProcessing.DataProcessing.StatisticsPointListCode as code
ModuleNotFoundError: No module named 'ClearMap.ParallelProcessing.DataProcessing.StatisticsPointListCode'
```
This error was introduced by moving the StatisticsPointList into a folder, but didn't update the import path in the py file. This pull request adds that fix.