### PR TITLE
[FIX] Bug fix for CELLMAP group analysis

### DIFF
--- a/ClearMap/Utils/path_utils.py
+++ b/ClearMap/Utils/path_utils.py
@@ -37,13 +37,32 @@ def is_density_file(f_name):
     return f_name.endswith('density_counts.tif')  # FIXME add menu for alternatives
 
 
-def find_density_file(target_dir, channel, suffix=''):
+def find_density_file(target_dir, channel, suffix='', debug=False):
     target_dir = Path(target_dir)
     extensions = [ext[1:] for ext in EXTENSIONS['image']]
-    pattern = f'{channel}_density*{suffix}.'
+    pattern = ''
+    if debug:
+        pattern = f'debug_.'
+    if suffix is None or suffix == '':
+        pattern = pattern.join(f'*{channel}_density*.')
+    else :
+        pattern = pattern.join(f'*{channel}_density*{suffix}.')
     files = []
     for ext in extensions:
-        files.extend(target_dir.glob(pattern + ext))
+        all_files = list(target_dir.glob(pattern + ext))
+
+        if len(all_files) > 1:
+            debug_files = [f for f in all_files if 'debug' in f.name]
+            non_debug_files = [f for f in all_files if 'debug' not in f.name]
+
+            if debug:
+                selected_files = debug_files
+            else:
+                selected_files = non_debug_files
+        else:
+            selected_files = all_files
+        files.extend(selected_files)
+
     return files[0] if files else None
     # return find_file(target_dir, is_density_file, 'density')
 

--- a/ClearMap/gui/tabs.py
+++ b/ClearMap/gui/tabs.py
@@ -2141,12 +2141,14 @@ class GroupAnalysisProcessor:
 
     def compute_p_vals(self, selected_comparisons, groups, wrapping_func, channels,
                        advanced=False, density_files_suffix=''):
+        if density_files_suffix is None :
+            density_files_suffix = ''
         for pair in selected_comparisons:
             gp1_name, gp2_name = pair
             gp1, gp2 = [groups[gp_name] for gp_name in pair]
             for channel in channels:
                 _ = density_files_are_comparable(self.results_folder, gp1, gp2, channel,
-                                                 density_file_suffix=density_files_suffix)
+                                                 density_files_suffix=density_files_suffix)
             check_ids_are_unique(gp1, gp2)
             # compare_groups is automatically for each channel (loads the first sample to find the channels)
             wrapping_func(compare_groups, self.results_folder, gp1_name, gp2_name, gp1, gp2,


### PR DESCRIPTION
Fixed several bugs :

A parameter had an incorrect name.
Debug files were mistakenly included in the comparison process.
File names were incorrectly generated due to suffix issues (None appearing in names or double underscores __), which caused problems during both reading and writing.
