### PR TITLE
Scan properties of a GT (graph) file, Allow partial GT file loading

### DIFF
--- a/ClearMap/Analysis/graphs/graph_gt.py
+++ b/ClearMap/Analysis/graphs/graph_gt.py
@@ -1269,6 +1269,51 @@ class Graph(grp.AnnotatedGraph):
         graph = Graph(base=g)
         graph.path = str(filename)
         return graph
+    
+    @staticmethod
+    def partial_load(filename, exclude_edge_geometry_properties=False, include_dict={}, exclude_dict={}, include=[], exclude=[]):
+        """
+        Partially load a graph from a file, allowing for inclusion and exclusion of specific properties.
+
+        Five options are available, in order of precedence:
+            1. exclude_geometry_properties: If True, all edge geometry properties (those starting with 'edge_geometry_') are excluded.
+            2. include_dict: A dictionary specifying which properties to include for each scope ('vertex', 'edge', 'graph').
+            3. exclude_dict: A dictionary specifying which properties to exclude for each scope ('vertex', 'edge', 'graph').
+            4. include: A list of property names to include across all scopes.
+            5. exclude: A list of property names to exclude across all scopes.
+        
+        Note: To know which properties are available in the file, use Graph.scan_gt_properties(filename, as_dict=True).
+        """
+
+        props = Graph.scan_gt_properties(filename, as_dict=True)
+
+        if exclude_edge_geometry_properties:
+            props["graph"] = [p for p in props["graph"] if p.startswith('edge_geometry_')]
+            return Graph.load(filename, ignore_gp=props["graph"])
+        
+        if include_dict:
+            ignore_vp = [p for p in props["vertex"] if p not in include_dict.get("vertex", [])]
+            ignore_ep = [p for p in props["edge"] if p not in include_dict.get("edge", [])]
+            ignore_gp = [p for p in props["graph"] if p not in include_dict.get("graph", [])]
+            return Graph.load(filename, ignore_vp=ignore_vp, ignore_ep=ignore_ep, ignore_gp=ignore_gp)
+        
+        if exclude_dict:
+            ignore_vp = [p for p in props["vertex"] if p in exclude_dict.get("vertex", [])]
+            ignore_ep = [p for p in props["edge"] if p in exclude_dict.get("edge", [])]
+            ignore_gp = [p for p in props["graph"] if p in exclude_dict.get("graph", [])]
+            return Graph.load(filename, ignore_vp=ignore_vp, ignore_ep=ignore_ep, ignore_gp=ignore_gp)
+        
+        if include:
+            ignore_vp = [p for p in props["vertex"] if p not in include]
+            ignore_ep = [p for p in props["edge"] if p not in include]
+            ignore_gp = [p for p in props["graph"] if p not in include]
+            return Graph.load(filename, ignore_vp=ignore_vp, ignore_ep=ignore_ep, ignore_gp=ignore_gp)
+        
+        if exclude:
+            ignore_vp = [p for p in props["vertex"] if p in exclude]
+            ignore_ep = [p for p in props["edge"] if p in exclude]
+            ignore_gp = [p for p in props["graph"] if p in exclude]
+            return Graph.load(filename, ignore_vp=ignore_vp, ignore_ep=ignore_ep, ignore_gp=ignore_gp)
 
 
 def load(filename):

--- a/ClearMap/Analysis/graphs/graph_gt.py
+++ b/ClearMap/Analysis/graphs/graph_gt.py
@@ -21,6 +21,7 @@ import graph_tool as gt
 import graph_tool.util as gtu
 import graph_tool.topology as gtt
 import graph_tool.generation as gtg
+import warnings
 
 # fix graph tool saving / loading for very large arrays
 import ClearMap.Analysis.graphs.graph as grp
@@ -1241,12 +1242,17 @@ class Graph(grp.AnnotatedGraph):
                     new_base.ep[name] = q
                 return Graph(name=copy.copy(self.name), base=new_base)
 
+    @staticmethod
+    def load(filename):
+        g = gt.load_graph(str(filename))
+        graph = Graph(base=g)
+        graph.path = str(filename)
+        return graph
+
 
 def load(filename):
-    g = gt.load_graph(str(filename))
-    graph = Graph(base=g)
-    graph.path = str(filename)
-    return graph
+    warnings.warn("Use Graph.load() instead of load()", DeprecationWarning)
+    return Graph.load(filename)
 
 
 def save(filename, graph):

--- a/ClearMap/Analysis/graphs/graph_gt.py
+++ b/ClearMap/Analysis/graphs/graph_gt.py
@@ -1262,16 +1262,16 @@ class Graph(grp.AnnotatedGraph):
             return out
         return props
 
-    @staticmethod
-    def load(filename, ignore_vp=None, ignore_ep=None,
+    @classmethod
+    def load(cls, filename, ignore_vp=None, ignore_ep=None,
                 ignore_gp=None):            
         g = gt.load_graph(str(filename), ignore_vp=ignore_vp, ignore_ep=ignore_ep, ignore_gp=ignore_gp)
-        graph = Graph(base=g)
+        graph = cls(base=g)
         graph.path = str(filename)
         return graph
     
-    @staticmethod
-    def partial_load(filename, exclude_edge_geometry_properties=False, include_dict={}, exclude_dict={}, include=[], exclude=[]):
+    @classmethod
+    def partial_load(cls, filename, exclude_edge_geometry_properties=False, include_dict={}, exclude_dict={}, include=[], exclude=[]):
         """
         Partially load a graph from a file, allowing for inclusion and exclusion of specific properties.
 
@@ -1285,35 +1285,35 @@ class Graph(grp.AnnotatedGraph):
         Note: To know which properties are available in the file, use Graph.scan_gt_properties(filename, as_dict=True).
         """
 
-        props = Graph.scan_gt_properties(filename, as_dict=True)
+        props = cls.scan_gt_properties(filename, as_dict=True)
 
         if exclude_edge_geometry_properties:
             props["graph"] = [p for p in props["graph"] if p.startswith('edge_geometry_')]
-            return Graph.load(filename, ignore_gp=props["graph"])
-        
+            return cls.load(filename, ignore_gp=props["graph"])
+
         if include_dict:
             ignore_vp = [p for p in props["vertex"] if p not in include_dict.get("vertex", [])]
             ignore_ep = [p for p in props["edge"] if p not in include_dict.get("edge", [])]
             ignore_gp = [p for p in props["graph"] if p not in include_dict.get("graph", [])]
-            return Graph.load(filename, ignore_vp=ignore_vp, ignore_ep=ignore_ep, ignore_gp=ignore_gp)
+            return cls.load(filename, ignore_vp=ignore_vp, ignore_ep=ignore_ep, ignore_gp=ignore_gp)
         
         if exclude_dict:
             ignore_vp = [p for p in props["vertex"] if p in exclude_dict.get("vertex", [])]
             ignore_ep = [p for p in props["edge"] if p in exclude_dict.get("edge", [])]
             ignore_gp = [p for p in props["graph"] if p in exclude_dict.get("graph", [])]
-            return Graph.load(filename, ignore_vp=ignore_vp, ignore_ep=ignore_ep, ignore_gp=ignore_gp)
+            return cls.load(filename, ignore_vp=ignore_vp, ignore_ep=ignore_ep, ignore_gp=ignore_gp)
         
         if include:
             ignore_vp = [p for p in props["vertex"] if p not in include]
             ignore_ep = [p for p in props["edge"] if p not in include]
             ignore_gp = [p for p in props["graph"] if p not in include]
-            return Graph.load(filename, ignore_vp=ignore_vp, ignore_ep=ignore_ep, ignore_gp=ignore_gp)
+            return cls.load(filename, ignore_vp=ignore_vp, ignore_ep=ignore_ep, ignore_gp=ignore_gp)
         
         if exclude:
             ignore_vp = [p for p in props["vertex"] if p in exclude]
             ignore_ep = [p for p in props["edge"] if p in exclude]
             ignore_gp = [p for p in props["graph"] if p in exclude]
-            return Graph.load(filename, ignore_vp=ignore_vp, ignore_ep=ignore_ep, ignore_gp=ignore_gp)
+            return cls.load(filename, ignore_vp=ignore_vp, ignore_ep=ignore_ep, ignore_gp=ignore_gp)
 
 
 def load(filename):

--- a/ClearMap/Analysis/graphs/graph_gt.py
+++ b/ClearMap/Analysis/graphs/graph_gt.py
@@ -1264,7 +1264,7 @@ class Graph(grp.AnnotatedGraph):
 
     @staticmethod
     def load(filename, ignore_vp=None, ignore_ep=None,
-                ignore_gp=None, exclude_edge_geometry=False):            
+                ignore_gp=None):            
         g = gt.load_graph(str(filename), ignore_vp=ignore_vp, ignore_ep=ignore_ep, ignore_gp=ignore_gp)
         graph = Graph(base=g)
         graph.path = str(filename)

--- a/ClearMap/Analysis/graphs/utils.py
+++ b/ClearMap/Analysis/graphs/utils.py
@@ -1,10 +1,167 @@
 import sys
+import mmap
+import struct
 
 import graph_tool as gt
 import numpy as np
 
 from ClearMap.External import pickle_python_3 as pickle
 
+
+
+# ---- Type tables for properties scanner -----------------------------------------------------------
+# Known value-type byte codes used by graph-tool. These have been stable for years.
+# If you hit a ValueError with an unknown code, add it here (and in TYPE_SIZES).
+TYPE_NAMES = {
+    0x00: "bool",            # stored as 1 byte (uchar)
+    0x01: "int16_t",
+    0x02: "int32_t",
+    0x03: "int64_t",
+    0x04: "double",
+    0x05: "long double",     # 16 bytes on x86_64 builds; treat as 16 here
+    0x06: "string",
+    0x07: "vector<bool>",
+    0x08: "vector<int16_t>",
+    0x09: "vector<int32_t>",
+    0x0A: "vector<int64_t>",
+    0x0B: "vector<double>",
+    0x0C: "vector<long double>",
+    0x0D: "vector<string>",
+    0x0E: "python::object",  # pickled bytes (length-prefixed string)
+    # The following two are present in recent versions:
+    0x0F: "int8_t",          # signed 8-bit (rare but supported)
+    0x10: "uint64_t",        # unsigned long (common for IDs/counters)
+}
+
+# Fixed-width sizes for scalar codes (others are length-prefixed)
+TYPE_SIZES = {
+    0x00: 1,   # bool (uchar)
+    0x0F: 1,   # int8_t
+    0x01: 2,   # int16_t
+    0x02: 4,   # int32_t
+    0x03: 8,   # int64_t
+    0x04: 8,   # double
+    0x05: 16,  # long double (graph-tool writes 16 bytes)
+    0x10: 8,   # uint64_t
+}
+
+# vector element sizes
+VEC_ELEM_SIZE = {
+    0x07: 1,    # vector<bool> (as bytes)
+    0x08: 2,    # vector<int16_t>
+    0x09: 4,    # vector<int32_t>
+    0x0A: 8,    # vector<int64_t>
+    0x0B: 8,    # vector<double>
+    0x0C: 16,   # vector<long double)
+}
+
+SCOPE = {0x00: "graph", 0x01: "vertex", 0x02: "edge"}
+
+# ---- Helpers for properties scanner ---------------------------------------------------------------
+def u8(mm, off):
+    return mm[off], off + 1
+
+def u64(mm, off, endian):
+    return struct.unpack(endian + 'Q', mm[off:off+8])[0], off + 8
+
+def read_str(mm, off, endian):
+    L, off = u64(mm, off, endian)
+    s = mm[off:off+L].decode('utf-8', errors='strict')
+    return s, off + L
+
+def skip_str(mm, off, endian):
+    L, off = u64(mm, off, endian)
+    return off + L
+
+def skip_vec_scalar(mm, off, endian, elem_size):
+    L, off = u64(mm, off, endian)
+    return off + L * elem_size
+
+def skip_vec_string(mm, off, endian):
+    L, off = u64(mm, off, endian)
+    for _ in range(L):
+        off = skip_str(mm, off, endian)
+    return off
+
+def idx_width_for_N(N):
+    if N <= 0xFF: return 1
+    if N <= 0xFFFF: return 2
+    if N <= 0xFFFFFFFF: return 4
+    return 8
+
+# -------------- properties scanner ----------------------------------------------------------------
+
+def scan_gt_props(path):
+    """Scan a .gt file and return a list of (scope, name, type-name) for each property."""
+    out = []
+    with open(path, 'rb') as f, mmap.mmap(f.fileno(), 0, access=mmap.ACCESS_READ) as mm:
+        off = 0
+
+        # Magic "\xe2\x9b\xbe gt" (the teacup), version, endianness
+        if len(mm) < 8 or mm[:6] != b'\xe2\x9b\xbe gt':
+            raise ValueError("Not a .gt file (bad magic)")
+        off = 6
+        version, off = u8(mm, off)
+        endian_flag, off = u8(mm, off)
+        endian = '<' if endian_flag == 0x00 else '>'
+
+        # Comment (length-prefixed UTF-8). Your example shows stats in here.
+        comment, off = read_str(mm, off, endian)
+        # print("comment:", comment)  # optional
+
+        # Graph structure
+        directed_flag, off = u8(mm, off)
+        N, off = u64(mm, off, endian)
+
+        idx_sz = idx_width_for_N(N)
+        E = 0
+        for _ in range(N):
+            d_i, off = u64(mm, off, endian)
+            E += d_i
+            off += d_i * idx_sz  # skip neighbors
+
+        # If undirected, E is the number of stored adjacency entries (one per edge).
+        # That is exactly the number of edge-property values that follow.
+
+        # Properties
+        total_props, off = u64(mm, off, endian)
+
+        for _ in range(total_props):
+            scope_code, off = u8(mm, off)
+            name, off = read_str(mm, off, endian)
+            vtype, off = u8(mm, off)
+
+            scope = SCOPE.get(scope_code, f"unknown({scope_code})")
+            vname = TYPE_NAMES.get(vtype, None)
+            if vname is None:
+                raise ValueError(f"Unknown value-type code 0x{vtype:02x} at file offset {off-1}. "
+                                 f"Please extend TYPE_NAMES/TYPE_SIZES/VEC_ELEM_SIZE as needed.")
+
+            out.append((scope, name, vname))
+
+            # Decide how many values to skip
+            count = 1 if scope_code == 0x00 else (N if scope_code == 0x01 else E)
+
+            # Skip payload
+            if vtype in TYPE_SIZES:               # fixed-width scalar (incl. uint64 and long double)
+                off += TYPE_SIZES[vtype] * count
+            elif vtype == 0x06:                   # string
+                for _ in range(count):
+                    off = skip_str(mm, off, endian)
+            elif vtype in VEC_ELEM_SIZE:          # vector<T> where T is scalar
+                for _ in range(count):
+                    off = skip_vec_scalar(mm, off, endian, VEC_ELEM_SIZE[vtype])
+            elif vtype == 0x0D:                   # vector<string>
+                for _ in range(count):
+                    off = skip_vec_string(mm, off, endian)
+            elif vtype == 0x0E:                   # python::object (bytes, length-prefixed)
+                for _ in range(count):
+                    off = skip_str(mm, off, endian)
+            else:
+                # Should be unreachable due to earlier guard
+                raise ValueError(f"Unhandled type 0x{vtype:02x} at {off}")
+    return out
+# --------------------------------------------------------------------------------------------------
 
 def pickler(stream, obj):
     sstream = gt.gt_io.BytesIO()

--- a/ClearMap/Scripts/partial_gt_load_demo.py
+++ b/ClearMap/Scripts/partial_gt_load_demo.py
@@ -1,0 +1,54 @@
+# A simple demo script to test partial loading of graph properties from a .gt file.
+# Usage: python partial_gt_load_demo.py /path/to/graph.gt
+# Please modify the path to ClearMap below if necessary.
+
+
+
+import sys
+import os
+
+USER = os.getenv("USER")
+sys.path.insert(0, f"/home/{USER}/code/ClearAnatomics/ClearMap")
+
+from ClearMap.Analysis.graphs.graph_gt import Graph
+from loguru import logger
+
+
+def stat_graph_properties(g):
+    return len(list(g.graph_properties)), len(list(g.vertex_properties)), len(list(g.edge_properties))
+
+if __name__ == "__main__":
+
+    # path of the graph file
+    path = sys.argv[1] 
+
+    logger.info("Scanning graph properties...")
+    props = Graph.scan_gt_properties(path)
+    logger.success(f"Found {len(props)} properties")
+    props = Graph.scan_gt_properties(path, as_dict=True)
+    logger.info(props)
+
+    logger.info("Testing exclude edge_geometry_properties...")
+    g = Graph.partial_load(path, exclude_edge_geometry_properties=True)
+    n_gp, n_vp, n_ep = stat_graph_properties(g)
+    logger.success(f"Graph properties: {n_gp}, Vertex properties: {n_vp}, Edge properties: {n_ep}")
+
+    logger.info("Testing include dict...")
+    g = Graph.partial_load(path, include_dict={'vertex': ['coordinates'], 'edge': ['length']})
+    n_gp, n_vp, n_ep = stat_graph_properties(g)
+    logger.success(f"Graph properties: {n_gp}, Vertex properties: {n_vp}, Edge properties: {n_ep}")
+
+    logger.info("Testing exclude dict...")
+    g = Graph.partial_load(path, exclude_dict={'vertex': ['coordinates'], 'edge': ['radii'], "graph": ['edge_geometry_coordinates', 'edge_geometry_radii', 'edge_geometry_coordinates_atlas', 'edge_geometry_radii_atlas', 'edge_geometry_annotation', 'edge_geometry_distance_to_surface', 'edge_geometry_coordinates_mri', 'edge_geometry_length_coordinates', 'edge_geometry_length_coordinates_mri', 'edge_geometry_length_coordinates_atlas']})
+    n_gp, n_vp, n_ep = stat_graph_properties(g)
+    logger.success(f"Graph properties: {n_gp}, Vertex properties: {n_vp}, Edge properties: {n_ep}")
+
+    logger.info("Testing include...")
+    g = Graph.partial_load(path, include=['edge_geometry_coordinates', "shape", 'edge_geometry_type', "coordinates"] )
+    n_gp, n_vp, n_ep = stat_graph_properties(g)
+    logger.success(f"Graph properties: {n_gp}, Vertex properties: {n_vp}, Edge properties: {n_ep}")
+
+    logger.info("Testing exclude...")
+    g = Graph.partial_load(path, exclude=['edge_geometry_coordinates', "shape", 'edge_geometry_type', "coordinates"])
+    n_gp, n_vp, n_ep = stat_graph_properties(g)
+    logger.success(f"Graph properties: {n_gp}, Vertex properties: {n_vp}, Edge properties: {n_ep}")


### PR DESCRIPTION
The intention of this PR is to add several conveniences.

```python
from ClearMap.Analysis.graphs.graph_gt import Graph
props = Graph.scan_gt_properties(path, as_dict=True)
print(props)
```
prints:
```raw
{'vertex': ['coordinates', 'radii',...], 
'edge': ['length', 'radii', ...], 
'graph': ['shape', 'edge_geometry_type', 'edge_geometry_coordinates', ...]}
```
... while a partial_load function allows for faster loading of a graph, when some properties are not needed, for instance:
```python
g = Graph.partial_load(path, exclude_edge_geometry_properties=True)
```

This also solves Issue #152

 

