### PR TITLE
Perf fix: colocalization

### DIFF
--- a/ClearMap/Analysis/colocalization/parallelism.py
+++ b/ClearMap/Analysis/colocalization/parallelism.py
@@ -118,7 +118,7 @@ def compare(
     cols = [f"center of bounding box {coord_name}" for coord_name in coord_names]
     points_0 = c0_result[cols].to_numpy() * np.array(scale).reshape((1, -1))
     points_1 = c1_result[cols].to_numpy() * np.array(scale).reshape((1, -1))
-    learner = neighbors.NearestNeighbors(n_neighbors=1, algorithm="brute", n_jobs=-1)
+    learner = neighbors.NearestNeighbors(n_neighbors=1, n_jobs=-1)
 
     learner.fit(points_1)
     if len(points_1) > 0:

--- a/ClearMap/Analysis/graphs/graph_gt.py
+++ b/ClearMap/Analysis/graphs/graph_gt.py
@@ -454,7 +454,7 @@ class Graph(grp.AnnotatedGraph):
 
     def vertex_radii(self, vertex=None):  # FIXME: hacky to have 2 return options (hides)
         if 'radii' in self.vertex_properties:
-        return self.vertex_property('radii', vertex=vertex)
+            return self.vertex_property('radii', vertex=vertex)
         else:
             return self.vertex_properties('radius_units', vertex=vertex)
 


### PR DESCRIPTION
After some tests it turns out the other algorithms are as precise as the 'brute' option and the 'auto' option entails at least a factor 100 performance gain for big points populations (10**5 or 10**6 points sets).